### PR TITLE
Upgrade `sphinx-action` to use `python=3.10`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.9"
+  - "3.10"
 install:
   - pip install -r requirements.txt
   - pip install black codecov coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 


### PR DESCRIPTION
**Context:**

With PennyLane now supporting `python>=3.10`, the restriction of `sphinx-action` to `python=3.9` caused errors when using newer syntax (e.g., `match-case`). See this [PR workflow error](https://github.com/PennyLaneAI/pennylane/actions/runs/12167757899/job/33937307574?pr=6657) for an example.

[sc-79772]