### PR TITLE
Update minimum python version to `3.11`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.10"
+  - "3.11"
 install:
   - pip install -r requirements.txt
   - pip install black codecov coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 


### PR DESCRIPTION
This is causing [failures](https://github.com/PennyLaneAI/pennylane-qiskit/actions/runs/16706920837/job/47286345306?pr=649) in the sphinx actions of the plug-ins.

<img width="1252" height="422" alt="image" src="https://github.com/user-attachments/assets/ef6e7ffc-54b4-44ef-afd7-9f7efdbe79fb" />


[sc-95555]